### PR TITLE
Makefile: replace GCC executables with env. vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-SRC_DIR     := src
-BIN_DIR     := bin
-OBJ_DIR     := .build
+SRC_DIR   := src
+BIN_DIR   := bin
+OBJ_DIR   := .build
 
-CXX_FLAGS   := -std=gnu++11 -Wall
-CC_FLAGS    := -std=gnu99 -Wall
-LD_FLAGS    :=
+CC        ?= gcc
+CXX       ?= g++
+
+CXX_FLAGS := -std=gnu++11 -Wall
+CC_FLAGS  := -std=gnu99 -Wall
+LD_FLAGS  :=
 
 ifeq ($(DEBUG), 1)
   CXX_FLAGS += -O0 -g
@@ -14,8 +17,8 @@ else
   CC_FLAGS += -O3 -flto
 endif
 
-OBJ			:= $(OBJ_DIR)/sfcRom.o $(OBJ_DIR)/superfamicheck.o
-HEADERS     := $(wildcard $(SRC_DIR)/*.h)
+OBJ       := $(OBJ_DIR)/sfcRom.o $(OBJ_DIR)/superfamicheck.o
+HEADERS   := $(wildcard $(SRC_DIR)/*.h)
 
 .PHONY: clean
 
@@ -26,13 +29,13 @@ all: clean superfamicheck
 superfamicheck: $(BIN_DIR)/superfamicheck
 
 $(BIN_DIR)/superfamicheck : $(OBJ) | $(BIN_DIR)
-	g++ $(LD_FLAGS) $^ -o $@
+	$(CXX) $(LD_FLAGS) $^ -o $@
 
 $(OBJ_DIR)/%.o : ./**/%.cpp $(HEADERS) | $(OBJ_DIR)
-	g++ $(CXX_FLAGS) -c $< -o $@
+	$(CXX) $(CXX_FLAGS) -c $< -o $@
 
 $(OBJ_DIR)/%.o : ./**/%.c $(HEADERS) | $(OBJ_DIR)
-	gcc $(CC_FLAGS) -c $< -o $@
+	$(CC) $(CC_FLAGS) -c $< -o $@
 
 $(BIN_DIR):
 	@mkdir -pv $@


### PR DESCRIPTION
This allows the build to work on FreeBSD, which ships with clang and not gcc.  (Still needs `gmake` though...)